### PR TITLE
Add the generic struct support

### DIFF
--- a/goextractors/definition_test.go
+++ b/goextractors/definition_test.go
@@ -30,12 +30,13 @@ func TestDefinitionExtractor(t *testing.T) {
 	assert.Empty(t, issues)
 
 	defs := extractCtx.Definitions
+
 	key := "github.com/vorlif/testdata.M"
 	if assert.Contains(t, defs, key) {
 		assert.Contains(t, defs[key], "Test")
 	}
 
-	key = "github.com/vorlif/testdata.func github.com/vorlif/testdata.noop(sing string, plural string, context string, domain string)"
+	key = "github.com/vorlif/testdata.noop"
 	if assert.Contains(t, defs, key) {
 		assert.Contains(t, defs[key], "sing")
 		assert.Contains(t, defs[key], "plural")
@@ -43,19 +44,19 @@ func TestDefinitionExtractor(t *testing.T) {
 		assert.Contains(t, defs[key], "domain")
 	}
 
-	key = "github.com/vorlif/testdata.func github.com/vorlif/testdata.multiNamesFunc(a string, b string)"
+	key = "github.com/vorlif/testdata.multiNamesFunc"
 	if assert.Contains(t, defs, key) {
 		assert.Contains(t, defs[key], "a")
 		assert.Contains(t, defs[key], "b")
 	}
 
-	key = "github.com/vorlif/testdata.func github.com/vorlif/testdata.noParamNames(string, string)"
+	key = "github.com/vorlif/testdata.noParamNames"
 	if assert.Contains(t, defs, key) {
 		assert.Contains(t, defs[key], "0")
 		assert.Contains(t, defs[key], "1")
 	}
 
-	key = "github.com/vorlif/testdata.func github.com/vorlif/testdata.variadicFunc(a string, vars ...string)"
+	key = "github.com/vorlif/testdata.variadicFunc"
 	if assert.Contains(t, defs, key) {
 		if assert.Contains(t, defs[key], "a") {
 			assert.Equal(t, 0, defs[key]["a"].FieldPos)

--- a/goextractors/definition_test.go
+++ b/goextractors/definition_test.go
@@ -36,6 +36,16 @@ func TestDefinitionExtractor(t *testing.T) {
 		assert.Contains(t, defs[key], "Test")
 	}
 
+	key = "github.com/vorlif/testdata.methodStruct.Method"
+	if assert.Contains(t, defs, key) {
+		assert.Contains(t, defs[key], "0")
+	}
+
+	key = "github.com/vorlif/testdata.genericMethodStruct.Method"
+	if assert.Contains(t, defs, key) {
+		assert.Contains(t, defs[key], "0")
+	}
+
 	key = "github.com/vorlif/testdata.noop"
 	if assert.Contains(t, defs, key) {
 		assert.Contains(t, defs[key], "sing")

--- a/goextractors/funccall_test.go
+++ b/goextractors/funccall_test.go
@@ -32,7 +32,7 @@ func TestFuncCallExtractor(t *testing.T) {
 
 		"constCtxMsg", "constCtxVal",
 
-		"struct-method-call",
+		"struct-method-call", "generic-struct-method-call",
 	}
 	got := collectIssueStrings(issues)
 	assert.ElementsMatch(t, want, got)

--- a/goextractors/funccall_test.go
+++ b/goextractors/funccall_test.go
@@ -31,6 +31,8 @@ func TestFuncCallExtractor(t *testing.T) {
 		"inline function",
 
 		"constCtxMsg", "constCtxVal",
+
+		"struct-method-call",
 	}
 	got := collectIssueStrings(issues)
 	assert.ElementsMatch(t, want, got)

--- a/goextractors/structdef.go
+++ b/goextractors/structdef.go
@@ -35,20 +35,23 @@ func (v structDefExtractor) Run(_ context.Context, extractCtx *extractors.Contex
 			return
 		}
 
-		var obj types.Object
-		var pkg *packages.Package
+		var ident *ast.Ident
 		switch val := node.Type.(type) {
 		case *ast.SelectorExpr:
-			pkg, obj = extractCtx.GetType(val.Sel)
-			if pkg == nil {
-				return
-			}
+			ident = val.Sel
 		case *ast.Ident:
-			pkg, obj = extractCtx.GetType(val)
-			if pkg == nil {
-				return
+			ident = val
+		case *ast.IndexExpr:
+			switch x := val.X.(type) {
+			case *ast.Ident:
+				ident = x
 			}
 		default:
+			return
+		}
+
+		pkg, obj := extractCtx.GetType(ident)
+		if pkg == nil {
 			return
 		}
 

--- a/goextractors/structdef_test.go
+++ b/goextractors/structdef_test.go
@@ -18,6 +18,8 @@ func TestStructDefExtractor(t *testing.T) {
 		"struct msgid arr2", "struct plural arr2",
 		"A3", "B3", "C3",
 		"A4", "B4", "C4",
+		"GA3", "GB3", "GC3",
+		"GA4", "GB4", "GC4",
 	}
 	assert.ElementsMatch(t, want, got)
 }

--- a/testdata/project/funccall.go
+++ b/testdata/project/funccall.go
@@ -24,6 +24,10 @@ type methodStruct struct{}
 
 func (methodStruct) Method(alias.Singular) {}
 
+type genericMethodStruct[T any] struct{}
+
+func (genericMethodStruct[T]) Method(alias.Singular) {}
+
 func outerFuncDef() {
 	f := func(msgid alias.Singular, plural alias.Plural, context alias.Context, domain alias.Domain) {}
 
@@ -84,4 +88,5 @@ func builtInFunctions() {
 
 func methodCall() {
 	(methodStruct{}).Method("struct-method-call")
+	(genericMethodStruct[string]{}).Method("generic-struct-method-call")
 }

--- a/testdata/project/funccall.go
+++ b/testdata/project/funccall.go
@@ -20,6 +20,10 @@ func GenericFunc[V int64 | float64](log alias.Singular, i V) V {
 	return i
 }
 
+type methodStruct struct{}
+
+func (methodStruct) Method(alias.Singular) {}
+
 func outerFuncDef() {
 	f := func(msgid alias.Singular, plural alias.Plural, context alias.Context, domain alias.Domain) {}
 
@@ -76,4 +80,8 @@ func builtInFunctions() {
 	t.NPGetf("context-np", "msgid-np", "pluralid-np", 10)
 	t.DPGetf("domain-dp", "context-dp", "singular-dp")
 	t.DNPGetf("domain-dnp", "context-dnp", "msgid-dnp", "pluralid-dnp", 10)
+}
+
+func methodCall() {
+	(methodStruct{}).Method("struct-method-call")
 }

--- a/testdata/project/struct.go
+++ b/testdata/project/struct.go
@@ -15,6 +15,10 @@ type OneLineStruct struct {
 	A, B, C localize.Singular
 }
 
+type OneLineGenericStruct[T any] struct {
+	A, B, C localize.Singular
+}
+
 func structLocalTest() []*sub.Sub {
 
 	// TRANSLATORS: Struct init
@@ -25,6 +29,15 @@ func structLocalTest() []*sub.Sub {
 	}
 
 	_ = OneLineStruct{"A4", "B4", "C4"}
+
+	// TRANSLATORS: Generic struct init
+	_ = OneLineGenericStruct[string]{
+		A: "GA3",
+		B: "GB3",
+		C: "GC3",
+	}
+
+	_ = OneLineGenericStruct[string]{"GA4", "GB4", "GC4"}
 
 	item := &sub.Sub{
 		Text:   "local struct msgid",

--- a/util/ast.go
+++ b/util/ast.go
@@ -3,12 +3,20 @@ package util
 import (
 	"fmt"
 	"go/types"
+	"strings"
 )
 
 func ObjToKey(obj types.Object) string {
 	switch v := obj.Type().(type) {
 	case *types.Signature:
 		if recv := v.Recv(); recv != nil {
+			// Strip out the generic type declaration from the type name.
+			// The ast.CallExpr reports its receiver as the actual type
+			// (e.g.`Generic[string]`), whereas the ast.FuncDecl on the
+			// same type as `Generic[T]`. The returned key values need
+			// to be consistent between different invocation patterns.
+			recv, _, _ := strings.Cut(recv.Type().String(), "[")
+
 			return fmt.Sprintf("%s.%s", recv, obj.Name())
 		}
 

--- a/util/ast.go
+++ b/util/ast.go
@@ -8,8 +8,10 @@ import (
 func ObjToKey(obj types.Object) string {
 	switch v := obj.Type().(type) {
 	case *types.Signature:
-		return fmt.Sprintf("%s.%s", obj.Pkg().Path(), obj.String())
-	case *types.Named:
+		if recv := v.Recv(); recv != nil {
+			return fmt.Sprintf("%s.%s", recv, obj.Name())
+		}
+
 		return fmt.Sprintf("%s.%s", obj.Pkg().Path(), obj.Name())
 	case *types.Pointer:
 		return v.Elem().String()


### PR DESCRIPTION
**Add support for extracting translations from generic struct fields and methods.**

The struct field extraction logic is aligned with the function call's extraction logic, and the generic struct handling logic is added.

**Redesign `util.ObjectToKey()` helper to support the generic struct use-case.**

The `funcCallExtractor` targets `*ast.CallExpr`, whereas the `definitionExtractorRunner` `*ast.FuncDecl` AST nodes. Using the `util.ObjectToKey()` helper on these two targets returns inconsistent object keys for the same logical AST node.

Given a generic struct

```golang
type Struct[T any] struct{}

func (Struct[T]) Method(localize.Singular) {}
```

used as

```golang
(Struct[string]{}).Method("To be translated")
```

resolves to the following object key specification

- `github.com/vorlif/testdata/debug.func (github.com/vorlif/testdata/debug.GenericStruct[string]).Method(string)` for the `funcCallExtractor`, but
- `github.com/vorlif/testdata/debug.func (github.com/vorlif/testdata/debug.GenericStruct[T]).Method(string)` for the `definitionExtractorRunner`

resulting in translation targets not being mappable between different invocations, and omitted from the output.

The change in design introduces a simplified object keying pattern, which relies on symbol names being unique within a package context to generate globally unique keys, allowing more control over the key's format.

The `*ast.CallExpr` and `*ast.FuncDecl` type name formatting discrepancy is solved by reformatting the type name string. This simplistic approach is used due to the `*types.Signature` type's limited API which doesn't expose higher granularity typing information.