### PR TITLE
Add ability to search the translations definition in imported packages

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -39,81 +39,30 @@ func init() {
 
 	fs := rootCmd.Flags()
 	fs.SortFlags = false
-	fs.StringVarP(&extractCfg.ExtractFormat,
-		"format",
-		"f",
-		def.ExtractFormat,
-		"Output format of the extraction. Valid values are 'pot' and 'json'.",
-	)
+	fs.StringVarP(&extractCfg.ExtractFormat, "format", "f", def.ExtractFormat, "Output format of the extraction. Valid values are 'pot' and 'json'.")
 	fs.StringVarP(&extractCfg.SourceDir, "directory", "D", def.SourceDir, "Directory with the Go source files")
-	fs.StringVarP(&extractCfg.OutputDir,
-		"output-dir",
-		"p",
-		def.OutputDir,
-		"Directory in which the pot files are stored.",
-	)
+	fs.StringVarP(&extractCfg.OutputDir, "output-dir", "p", def.OutputDir, "Directory in which the pot files are stored.")
 	fs.StringVarP(&extractCfg.OutputFile, "output", "o", def.OutputFile, "Write output to specified file")
-	fs.StringSliceVarP(&extractCfg.CommentPrefixes,
-		"add-comments",
-		"c",
-		def.CommentPrefixes,
-		"Place comment blocks starting with TAG and preceding keyword lines in output file",
-	)
-	fs.BoolVarP(&extractCfg.ExtractErrors,
-		"extract-errors",
-		"e",
-		def.ExtractErrors,
-		"Strings from errors.New(STRING) are extracted",
-	)
-	fs.StringVar(&extractCfg.ErrorContext,
-		"errors-context",
-		def.ErrorContext,
-		"Context which is automatically assigned to extracted errors",
-	)
+	fs.StringSliceVarP(&extractCfg.CommentPrefixes, "add-comments", "c", def.CommentPrefixes, "Place comment blocks starting with TAG and preceding keyword lines in output file")
+	fs.BoolVarP(&extractCfg.ExtractErrors, "extract-errors", "e", def.ExtractErrors, "Strings from errors.New(STRING) are extracted")
+	fs.StringVar(&extractCfg.ErrorContext, "errors-context", def.ErrorContext, "Context which is automatically assigned to extracted errors")
 
-	fs.StringArrayVarP(&extractCfg.TemplatePatterns,
-		"template-directory",
-		"t",
-		[]string{},
-		"Set a list of paths to which the template files contain. Regular expressions can be used.",
-	)
+	fs.StringArrayVarP(&extractCfg.TemplatePatterns, "template-directory", "t", []string{}, "Set a list of paths to which the template files contain. Regular expressions can be used.")
 	fs.String("template-prefix", "", "Sets a prefix for the translation functions, which is used within the templates")
-	fs.BoolVar(&extractCfg.TmplIsMonolingual,
-		"template-use-kv",
-		false,
-		"Determines whether the strings from templates should be handled as key-value",
-	)
-	fs.StringArrayP("template-keyword",
-		"k",
-		[]string{},
-		"Sets a keyword that is used within templates to identify translation functions",
-	)
+	fs.BoolVar(&extractCfg.TmplIsMonolingual, "template-use-kv", false, "Determines whether the strings from templates should be handled as key-value")
+	fs.StringArrayP("template-keyword", "k", []string{}, "Sets a keyword that is used within templates to identify translation functions")
 
-	fs.StringVarP(&extractCfg.DefaultDomain,
-		"default-domain",
-		"d",
-		def.DefaultDomain,
-		"Use name.pot for output (instead of messages.pot)",
-	)
+	fs.StringVarP(&extractCfg.DefaultDomain, "default-domain", "d", def.DefaultDomain, "Use name.pot for output (instead of messages.pot)")
 	fs.BoolVar(&extractCfg.WriteNoLocation, "no-location", def.WriteNoLocation, "Do not write '#: filename:line' lines")
 
 	fs.IntVarP(&extractCfg.WrapWidth, "width", "w", def.WrapWidth, "Set output page width")
-	fs.BoolVar(&extractCfg.DontWrap,
-		"no-wrap",
-		def.DontWrap,
-		"Do not break long message lines, longer than the output page width, into several lines",
-	)
+	fs.BoolVar(&extractCfg.DontWrap, "no-wrap", def.DontWrap, "Do not break long message lines, longer than the output page width, into several lines")
 
 	fs.BoolVar(&extractCfg.OmitHeader, "omit-header", def.OmitHeader, "Don't write header with 'msgid \"\"' entry")
 	fs.StringVar(&extractCfg.CopyrightHolder, "copyright-holder", def.CopyrightHolder, "Set copyright holder in output")
 	fs.StringVar(&extractCfg.PackageName, "package-name", def.PackageName, "Set package name in output")
 	fs.StringVar(&extractCfg.BugsAddress, "msgid-bugs-address", def.BugsAddress, "Set report address for msgid bugs")
-	fs.StringSliceVarP(&extractCfg.LoadedPackages,
-		"loaded-packages",
-		"l",
-		[]string{},
-		"List of packages divided by comma to search for translations",
-	)
+	fs.StringSliceVarP(&extractCfg.LoadedPackages, "loaded-packages", "l", []string{}, "List of packages divided by comma to search for translations")
 }
 
 func initVersionNumber() {

--- a/commands/root.go
+++ b/commands/root.go
@@ -39,29 +39,81 @@ func init() {
 
 	fs := rootCmd.Flags()
 	fs.SortFlags = false
-	fs.StringVarP(&extractCfg.ExtractFormat, "format", "f", def.ExtractFormat, "Output format of the extraction. Valid values are 'pot' and 'json'.")
+	fs.StringVarP(&extractCfg.ExtractFormat,
+		"format",
+		"f",
+		def.ExtractFormat,
+		"Output format of the extraction. Valid values are 'pot' and 'json'.",
+	)
 	fs.StringVarP(&extractCfg.SourceDir, "directory", "D", def.SourceDir, "Directory with the Go source files")
-	fs.StringVarP(&extractCfg.OutputDir, "output-dir", "p", def.OutputDir, "Directory in which the pot files are stored.")
+	fs.StringVarP(&extractCfg.OutputDir,
+		"output-dir",
+		"p",
+		def.OutputDir,
+		"Directory in which the pot files are stored.",
+	)
 	fs.StringVarP(&extractCfg.OutputFile, "output", "o", def.OutputFile, "Write output to specified file")
-	fs.StringSliceVarP(&extractCfg.CommentPrefixes, "add-comments", "c", def.CommentPrefixes, "Place comment blocks starting with TAG and preceding keyword lines in output file")
-	fs.BoolVarP(&extractCfg.ExtractErrors, "extract-errors", "e", def.ExtractErrors, "Strings from errors.New(STRING) are extracted")
-	fs.StringVar(&extractCfg.ErrorContext, "errors-context", def.ErrorContext, "Context which is automatically assigned to extracted errors")
+	fs.StringSliceVarP(&extractCfg.CommentPrefixes,
+		"add-comments",
+		"c",
+		def.CommentPrefixes,
+		"Place comment blocks starting with TAG and preceding keyword lines in output file",
+	)
+	fs.BoolVarP(&extractCfg.ExtractErrors,
+		"extract-errors",
+		"e",
+		def.ExtractErrors,
+		"Strings from errors.New(STRING) are extracted",
+	)
+	fs.StringVar(&extractCfg.ErrorContext,
+		"errors-context",
+		def.ErrorContext,
+		"Context which is automatically assigned to extracted errors",
+	)
 
-	fs.StringArrayVarP(&extractCfg.TemplatePatterns, "template-directory", "t", []string{}, "Set a list of paths to which the template files contain. Regular expressions can be used.")
+	fs.StringArrayVarP(&extractCfg.TemplatePatterns,
+		"template-directory",
+		"t",
+		[]string{},
+		"Set a list of paths to which the template files contain. Regular expressions can be used.",
+	)
 	fs.String("template-prefix", "", "Sets a prefix for the translation functions, which is used within the templates")
-	fs.BoolVar(&extractCfg.TmplIsMonolingual, "template-use-kv", false, "Determines whether the strings from templates should be handled as key-value")
-	fs.StringArrayP("template-keyword", "k", []string{}, "Sets a keyword that is used within templates to identify translation functions")
+	fs.BoolVar(&extractCfg.TmplIsMonolingual,
+		"template-use-kv",
+		false,
+		"Determines whether the strings from templates should be handled as key-value",
+	)
+	fs.StringArrayP("template-keyword",
+		"k",
+		[]string{},
+		"Sets a keyword that is used within templates to identify translation functions",
+	)
 
-	fs.StringVarP(&extractCfg.DefaultDomain, "default-domain", "d", def.DefaultDomain, "Use name.pot for output (instead of messages.pot)")
+	fs.StringVarP(&extractCfg.DefaultDomain,
+		"default-domain",
+		"d",
+		def.DefaultDomain,
+		"Use name.pot for output (instead of messages.pot)",
+	)
 	fs.BoolVar(&extractCfg.WriteNoLocation, "no-location", def.WriteNoLocation, "Do not write '#: filename:line' lines")
 
 	fs.IntVarP(&extractCfg.WrapWidth, "width", "w", def.WrapWidth, "Set output page width")
-	fs.BoolVar(&extractCfg.DontWrap, "no-wrap", def.DontWrap, "Do not break long message lines, longer than the output page width, into several lines")
+	fs.BoolVar(&extractCfg.DontWrap,
+		"no-wrap",
+		def.DontWrap,
+		"Do not break long message lines, longer than the output page width, into several lines",
+	)
 
 	fs.BoolVar(&extractCfg.OmitHeader, "omit-header", def.OmitHeader, "Don't write header with 'msgid \"\"' entry")
 	fs.StringVar(&extractCfg.CopyrightHolder, "copyright-holder", def.CopyrightHolder, "Set copyright holder in output")
 	fs.StringVar(&extractCfg.PackageName, "package-name", def.PackageName, "Set package name in output")
 	fs.StringVar(&extractCfg.BugsAddress, "msgid-bugs-address", def.BugsAddress, "Set report address for msgid bugs")
+	fs.StringSliceVarP(&extractCfg.LoadedPackages,
+		"loaded-packages",
+		"l",
+		[]string{},
+		"List of packages divided by comma to search for translations",
+	)
 }
 
 func initVersionNumber() {

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,8 @@ type Config struct {
 	MaxDepth int
 	Args     []string
 
+	LoadedPackages []string
+
 	Timeout time.Duration
 
 	ExtractFormat     string

--- a/extract/load.go
+++ b/extract/load.go
@@ -73,6 +73,15 @@ func (cl *ContextLoader) Load(ctx context.Context) (*extractors.Context, error) 
 		return nil, fmt.Errorf("failed to load packages: %w", err)
 	}
 
+	// Add loaded packages from config to originalPkgs
+	if len(cl.config.LoadedPackages) > 0 {
+		loadedPkgs, err := loadPackagesFromDir(pkgConf, cl.config.LoadedPackages)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load specified packages: %w", err)
+		}
+		originalPkgs = append(originalPkgs, loadedPkgs...)
+	}
+
 	if len(originalPkgs) == 0 {
 		return nil, errors.New("no go files to analyze")
 	}


### PR DESCRIPTION
The new CLI option --loaded-packages (alias -l) allows you to specify a list of additional imported packages to scan for strings that should be translated.

For example, you can create your own library for error definitions, such as github.com/my-repo/myerrors.

Inside that library, define a function for creating errors, like this:
 
```go
 func New(hint localize.Singular) error {}
 ```
 
Then, in your main project where translations are needed, import this error library and use it as follows:
 
 ```go
myerrors.New("Text to be translated")
 ```
 
 When you run xspreak with the new --loaded-packages flag, the string "Text to be translated" will be extracted and included in the generated .pot file:

 ```shell
 xspreak -l github.com/go-modulus/my-repo/myerrors
 ```
 
This also works if you create a separate library that contains strings to be translated. All translatable strings in the specified imported package(s) will be detected and extracted.
